### PR TITLE
rez package.py and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (bash)
 
 on:
   push:
@@ -45,7 +45,8 @@ jobs:
             - os: windows-latest
               piping: "|&"
             - os: macOS-latest
-              piping: "2>&1 |"
+              piping: "|&"
+              # piping: "2>&1 |"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,22 +13,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
 
     - name: Check executables
+      shell: bash
       run: |
         ls -l -h
         test -x ./colourise
         test -x ./colour-test
 
     - name: colourise --help
+      shell: bash
       run: ./colourise --help
 
     - name: colour-test --help
+      shell: bash
       run: ./colour-test --help
 
   test-colourise:
@@ -36,10 +38,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
             - os: ubuntu-latest
+              piping: "|&"
+            - os: windows-latest
               piping: "|&"
             - os: macOS-latest
               piping: "2>&1 |"
@@ -48,9 +51,11 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Shotgun Log (No Terminal)
+      shell: bash
       run: cat ./tests/resources/logs/tk-desktop.log | ./colourise --shotgun-log
 
     - name: Katana (No Terminal)
+      shell: bash
       run: ./tests/resources/bin/katana ${{ matrix.piping }} ./colourise --katana
 
   test-colourise-docker-pty:
@@ -83,16 +88,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
 
     - name: All
+      shell: bash
       run: ./colour-test
 
     - name: One at at time
+      shell: bash
       run: |
         ./colour-test --retro
         ./colour-test --combo
@@ -102,6 +108,7 @@ jobs:
         ./colour-test -3
 
     - name: Multiple in different order
+      shell: bash
       run: |
         ./colour-test -2 --retro
         ./colour-test --retro --3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,7 @@ jobs:
             - os: windows-latest
               piping: "|&"
             - os: macOS-latest
-              piping: "|&"
-              # piping: "2>&1 |"
+              piping: "2>&1 |"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,6 @@
-name: CI (bash)
+name: CI
 
-on:
-  push:
-    branches:
-      - '**'
-    tags-ignore:
-      - '**'
+on: [push]
 
 jobs:
   Install:

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -12,6 +12,7 @@ jobs:
     name: Can Install in rez
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
@@ -30,8 +31,8 @@ jobs:
         python2 -m pip install --target="_rez" .rez
         ls -l _rez/bin
         export PATH="$(pwd)/_rez/bin:${PATH}"
+        rez bind rez
         mkdir -vp "$(rez config local_packages_path)"
-        rez bind platform
         rez build --install
         rez view colourise
         rez env colourise -c '

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -28,10 +28,9 @@ jobs:
       run: |
         set -x
         git clone "https://github.com/nerdvegas/rez.git" .rez
-        python2 -m pip install --target="_rez" .rez
-        ls -l _rez/bin
-        export PATH="$(pwd)/_rez/bin:${PATH}"
-        rez bind rez
+        python2 -m pip install --user .rez
+        export PATH="${HOME}/.local/bin:${PATH}"
+        rez bind platform
         mkdir -vp "$(rez config local_packages_path)"
         rez build --install
         rez view colourise

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         set -x
         git clone "https://github.com/nerdvegas/rez.git" .rez
-        python2 -m pip install --prefix="_rez" .rez
+        python2 -m pip install --target="_rez" .rez
         export PATH="$(pwd)/_rez/bin:${PATH}"
         mkdir -vp "$(rez config local_packages_path)"
         rez bind platform

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -2,57 +2,29 @@ name: Rez package
 
 on:
   push:
-    branches-ignore:
-      - '**'
-    tags:
-      - '**'
+    branches-ignore: []
+    #   - '**'
+    # tags:
+    #   - '**'
 
 jobs:
-
-  test-colourise:
-    name: Can colourise in ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  install-rez:
+    name: Can Install in rez
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
-        include:
-            - os: ubuntu-latest
-              piping: "|&"
-            - os: macOS-latest
-              piping: "2>&1 |"
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Shotgun Log (No Terminal)
-      run: cat ./tests/resources/logs/tk-desktop.log | ./colourise --shotgun-log
-
-    - name: Katana (No Terminal)
-      run: ./tests/resources/bin/katana ${{ matrix.piping }} ./colourise --katana
-
-  test-colourise-docker-pty:
-    name: Can colourise in Pseudo Docker Terminal
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Shotgun Log
+    - name: Install rez and rez build --install
+      shell: bash
       run: |
-        docker run \
-          --rm \
-          --tty \
-          -v $(pwd):/usr/local/bin:ro \
-          -w /usr/local/bin centos:7 \
-          bash -c 'cat ./tests/resources/logs/tk-desktop.log | ./colourise --shotgun-log'
-
-    - name: Katana
-      run: |
-        docker run \
-          --rm \
-          --tty \
-          -v $(pwd):/usr/local/bin:ro \
-          -w /usr/local/bin centos:7 \
-          bash -c './tests/resources/bin/katana |& ./colourise --katana'
-
+        pushd $(mktemp -d)
+        git clone https://github.com/nerdvegas/rez.git .
+        python install.py
+        export PATH="${PATH}:/opt/rez/bin/rez"
+        mkdir -vp "$(rez config packages_path)"
+        popd
+        rez build --install
+        rez view colourise

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -9,12 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
-            - os: ubuntu-latest
-              piping: "|&"
-            - os: macOS-latest
-              piping: "2>&1 |"
+          - os: ubuntu-latest
+            piping: "|&"
+            bin-folder: "bin"
+          - os: windows-latest
+            piping: "|&"
+            bin-folder: "Scripts"
+          - os: macOS-latest
+            piping: "2>&1 |"
+            bin-folder: "bin"
 
     steps:
     - uses: actions/checkout@v1
@@ -26,11 +31,11 @@ jobs:
     - name: Install rez and rez build --install
       shell: bash
       run: |
-        set -x
+        set -x -o pipefail
         # Setup latest rez and paths (master branch)
         git clone "https://github.com/nerdvegas/rez.git" .rez
-        python2 -m pip install --user .rez
-        export PATH="${HOME}/.local/bin:${PATH}"
+        python .rez/install.py _rez
+        export PATH="$(pwd)/_rez/${{ matrix.bin-folder }}/rez:${PATH}"
         rez bind platform
         mkdir -vp "$(rez config local_packages_path)"
         # Test install i.e. package.py

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   install-rez:
     name: Can Install in rez
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -20,6 +21,7 @@ jobs:
     - name: Install rez and rez build --install
       shell: bash
       run: |
+        set -x
         pushd $(mktemp -d)
         git clone https://github.com/nerdvegas/rez.git .
         python install.py

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         set -x
         pushd $(mktemp -d)
-        git clone https://github.com/nerdvegas/rez.git .
+        git clone "https://github.com/nerdvegas/rez.git" .
         python install.py
         export PATH="${PATH}:/opt/rez/bin/rez"
         mkdir -vp "$(rez config local_packages_path)"
@@ -31,3 +31,7 @@ jobs:
         popd
         rez build --install
         rez view colourise
+        rez env colourise -c '
+          colour-test --help &&
+          colourise --help &&
+          ls -l $REZ_COLOURISE_ROOT'

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -1,20 +1,20 @@
-name: Rez package
+name: Rez
 
-on:
-  push:
-    branches-ignore: []
-    #   - '**'
-    # tags:
-    #   - '**'
+on: [push]
 
 jobs:
   install-rez:
-    name: Can Install in rez
+    name: Can install in rez on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
+        include:
+            - os: ubuntu-latest
+              piping: "|&"
+            - os: macOS-latest
+              piping: "2>&1 |"
 
     steps:
     - uses: actions/checkout@v1
@@ -27,14 +27,19 @@ jobs:
       shell: bash
       run: |
         set -x
+        # Setup latest rez and paths (master branch)
         git clone "https://github.com/nerdvegas/rez.git" .rez
         python2 -m pip install --user .rez
         export PATH="${HOME}/.local/bin:${PATH}"
         rez bind platform
         mkdir -vp "$(rez config local_packages_path)"
+        # Test install i.e. package.py
         rez build --install
         rez view colourise
         rez env colourise -c '
           colour-test --help &&
           colourise --help &&
           ls -l $REZ_COLOURISE_ROOT'
+        # Test main CI tests like in README.md
+        cat ./tests/resources/logs/tk-desktop.log | rez env colourise -- colourise --shotgun-log
+        ./tests/resources/bin/katana ${{ matrix.piping }} rez env colourise -- colourise --katana

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -1,35 +1,13 @@
-name: CI
+name: Rez package
 
 on:
   push:
-    branches:
+    branches-ignore:
       - '**'
-    tags-ignore:
+    tags:
       - '**'
 
 jobs:
-  Install:
-    name: Install in ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Check executables
-      run: |
-        ls -l -h
-        test -x ./colourise
-        test -x ./colour-test
-
-    - name: colourise --help
-      run: ./colourise --help
-
-    - name: colour-test --help
-      run: ./colour-test --help
 
   test-colourise:
     name: Can colourise in ${{ matrix.os }}
@@ -78,31 +56,3 @@ jobs:
           -w /usr/local/bin centos:7 \
           bash -c './tests/resources/bin/katana |& ./colourise --katana'
 
-  test-colour-test:
-    name: Can colour-test in ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: All
-      run: ./colour-test
-
-    - name: One at at time
-      run: |
-        ./colour-test --retro
-        ./colour-test --combo
-        ./colour-test --pretty
-        ./colour-test -1
-        ./colour-test -2
-        ./colour-test -3
-
-    - name: Multiple in different order
-      run: |
-        ./colour-test -2 --retro
-        ./colour-test --retro --3
-        ./colour-test -3 -2

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -28,6 +28,7 @@ jobs:
         set -x
         git clone "https://github.com/nerdvegas/rez.git" .rez
         python2 -m pip install --target="_rez" .rez
+        ls -l _rez/bin
         export PATH="$(pwd)/_rez/bin:${PATH}"
         mkdir -vp "$(rez config local_packages_path)"
         rez bind platform

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -27,6 +27,7 @@ jobs:
         python install.py
         export PATH="${PATH}:/opt/rez/bin/rez"
         mkdir -vp "$(rez config local_packages_path)"
+        rez bind platform
         popd
         rez build --install
         rez view colourise

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -9,17 +9,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
+        # os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
           - os: ubuntu-latest
             piping: "|&"
             bin-folder: "bin"
-          - os: windows-latest
-            piping: "|&"
-            bin-folder: "Scripts"
           - os: macOS-latest
             piping: "2>&1 |"
             bin-folder: "bin"
+          # - os: windows-latest
+          #   piping: "|&"
+          #   bin-folder: "Scripts"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -22,13 +22,11 @@ jobs:
       shell: bash
       run: |
         set -x
-        pushd $(mktemp -d)
-        git clone "https://github.com/nerdvegas/rez.git" .
-        python install.py
-        export PATH="${PATH}:/opt/rez/bin/rez"
+        git clone "https://github.com/nerdvegas/rez.git" .rez
+        python2 -m pip install --target "_rez" .rez
+        export PATH="$(pwd)/_rez/bin:${PATH}"
         mkdir -vp "$(rez config local_packages_path)"
         rez bind platform
-        popd
         rez build --install
         rez view colourise
         rez env colourise -c '

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -26,7 +26,7 @@ jobs:
         git clone https://github.com/nerdvegas/rez.git .
         python install.py
         export PATH="${PATH}:/opt/rez/bin/rez"
-        mkdir -vp "$(rez config packages_path)"
+        mkdir -vp "$(rez config local_packages_path)"
         popd
         rez build --install
         rez view colourise

--- a/.github/workflows/rez.yml
+++ b/.github/workflows/rez.yml
@@ -18,12 +18,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '2.7'
+
     - name: Install rez and rez build --install
       shell: bash
       run: |
         set -x
         git clone "https://github.com/nerdvegas/rez.git" .rez
-        python2 -m pip install --target "_rez" .rez
+        python2 -m pip install --prefix="_rez" .rez
         export PATH="$(pwd)/_rez/bin:${PATH}"
         mkdir -vp "$(rez config local_packages_path)"
         rez bind platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and
 this project adheres to [Semantic Versioning](https://semver.org).
 
 
+## [0.3.0] - 2019-10-25
+
+Now available as rez package.
+
+### Added
+
+- `package.py` for [rez package](https://github.com/nerdvegas/rez).
+- rez package install CI for Linux and OSX.
+- Windows (bash) tests for CI
+
+
 ## [0.2.0] - 2019-10-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Colourise Terminal Output
 
 [![CI Workflow Badge](https://github.com/wwfxuk/colourise/workflows/CI/badge.svg)](https://github.com/wwfxuk/colourise/actions?workflow=CI)
+[![Rez Workflow Badge](https://github.com/wwfxuk/colourise/workflows/Rez/badge.svg)](https://github.com/wwfxuk/colourise/actions?workflow=Rez)
 
 Colourise `stdin` using a specific parser.
 
@@ -36,11 +37,20 @@ katana |& colourise --katana
 
 1. Download the `colourise` file
 1. Make it executable e.g. `chmod a+x colourise`
-1. Start using it! e.g. `katana |& /full/path/to/colourise`
+1. Start using it! e.g. on Linux `katana |& /full/path/to/colourise --katana`
 
 Top tip: add the the folder where you downloaded `colourise` script to the
 `PATH` environment variable. Or just copy `colourise` to an existing folder
 on `PATH` e.g. `/usr/local/bin`
+
+### rez package
+
+You can also install this a a [rez package](https://github.com/nerdvegas/rez)
+
+1. Download or `git clone` this repository
+1. From the extracted repository root, run `rez build --install`
+1. Start using the `colourise` package e.g. on Mac OSX
+   `katana 2>&1 | rez env colourise -- colourise --katana`
 
 
 ## Bonus script: colour-test

--- a/package.py
+++ b/package.py
@@ -11,8 +11,8 @@ description = (
 
 authors = ['WWFX UK']
 
-# Technically needs bash. Tested rez on Linux and OSX CI with bash
-requires = ['platform-linux|osx']
+# # Technically needs bash. Tested rez on Windows, Linux and OSX CI with bash
+# requires = []
 
 tools = ['colourise', 'colour-test']  # Names of executables from this package
 # ---- OR ----

--- a/package.py
+++ b/package.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+name = 'colourise'
+
+version = '0.2.0'
+
+description = (
+    'If output to Terminal, colourise the piped input '
+    'text base off some rules.'
+)
+
+authors = ['WWFX UK']
+
+requires = ['platform-linux|osx']  # As tested by CI
+
+tools = ['colourise', 'colour-test']  # Names of executables from this package
+# ---- OR ----
+# @late()
+# def tools():
+#     """Dynamically get a list of binaries/wrappers from our bin folder.
+#
+#     Returns:
+#         list[str]: Names of binaries from the bin folder.
+#     """
+#     import os
+#     exe_names = []
+#     bin_folder = os.path.join(this.root, 'bin')
+#
+#     for name in os.listdir(bin_folder):
+#         full_path = os.path.join(bin_folder, name)
+#         if os.access(full_path, os.X_OK) and not os.path.isdir(full_path):
+#             exe_names.append(name)
+#
+#     return exe_names
+
+# # Technically needs tar, gzip and curl but they tend to come with OS
+# build_requires = []  # Build-time packages required by this package
+
+build_command = r'''
+set -euf -o pipefail
+
+# ---- Setup for: curl $CURL_FLAGS ... ----
+# Silent/no progress bar curl if not terminal (e.g. CI stdout or file logs)
+[ -t 1 ] && CURL_FLAGS="-#" || CURL_FLAGS="-sS"
+CURL_FLAGS+=" -L"
+
+if [[ $REZ_BUILD_INSTALL -eq 1 ]]
+then
+    curl $CURL_FLAGS \
+        https://github.com/wwfxuk/colourise/archive/{version}.tar.gz \
+    | tar -C "$REZ_BUILD_INSTALL_PATH" --strip-components=1 -xz \
+        colourise \
+        colour-test
+fi
+'''.format(version=version)
+
+
+def commands():
+    """Commands to set up environment for ``rez env colourise``"""
+    env.PATH.append('{root}')

--- a/package.py
+++ b/package.py
@@ -11,7 +11,8 @@ description = (
 
 authors = ['WWFX UK']
 
-requires = ['platform-linux|osx']  # As tested by CI
+# # Technically needs bash. Tested on CI Windows, Linux and OSX with bash
+# requires = []
 
 tools = ['colourise', 'colour-test']  # Names of executables from this package
 # ---- OR ----
@@ -49,8 +50,8 @@ then
     curl $CURL_FLAGS \
         https://github.com/wwfxuk/colourise/archive/{version}.tar.gz \
     | tar -C "$REZ_BUILD_INSTALL_PATH" --strip-components=1 -xz \
-        colourise \
-        colour-test
+        "*/colourise" \
+        "*/colour-test"
 fi
 '''.format(version=version)
 

--- a/package.py
+++ b/package.py
@@ -50,10 +50,9 @@ then
     curl $CURL_FLAGS \
         https://github.com/wwfxuk/colourise/archive/{version}.tar.gz \
     | tar -C "$REZ_BUILD_INSTALL_PATH" --strip-components=1 -xz \
-        "*/colourise" \
-        "*/colour-test"
+        --wildcards {tools}
 fi
-'''.format(version=version)
+'''.format(version=version, tools=' '.join('"*/{0}"'.format(t) for t in tools))
 
 
 def commands():

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = 'colourise'
 
-version = '0.2.0'
+version = '0.3.0'
 
 description = (
     'If output to Terminal, colourise the piped input '
@@ -25,10 +25,9 @@ tools = ['colourise', 'colour-test']  # Names of executables from this package
 #     """
 #     import os
 #     exe_names = []
-#     bin_folder = os.path.join(this.root, 'bin')
 #
-#     for name in os.listdir(bin_folder):
-#         full_path = os.path.join(bin_folder, name)
+#     for name in os.listdir(this.root):
+#         full_path = os.path.join(this.root, name)
 #         if os.access(full_path, os.X_OK) and not os.path.isdir(full_path):
 #             exe_names.append(name)
 #
@@ -40,21 +39,14 @@ tools = ['colourise', 'colour-test']  # Names of executables from this package
 build_command = r'''
 set -euf -o pipefail
 
-# ---- Setup for: curl $CURL_FLAGS ... ----
-# Silent/no progress bar curl if not terminal (e.g. CI stdout or file logs)
-[ -t 1 ] && CURL_FLAGS="-#" || CURL_FLAGS="-sS"
-CURL_FLAGS+=" -L"
-
-TAR_FLAGS="--strip-components=1 -xz"
-[ "$REZ_PLATFORM_VERSION" == "osx" ] || TAR_FLAGS+=" --wildcards"
-
 if [[ $REZ_BUILD_INSTALL -eq 1 ]]
 then
-    curl $CURL_FLAGS \
-        https://github.com/wwfxuk/colourise/archive/{version}.tar.gz \
-    | tar -C "$REZ_BUILD_INSTALL_PATH" $TAR_FLAGS {tools}
+    cp -v \
+        $REZ_BUILD_SOURCE_PATH/colourise \
+        $REZ_BUILD_SOURCE_PATH/colour-test \
+        $REZ_BUILD_INSTALL_PATH
 fi
-'''.format(version=version, tools=' '.join('"*/{0}"'.format(t) for t in tools))
+'''
 
 
 def commands():

--- a/package.py
+++ b/package.py
@@ -11,8 +11,8 @@ description = (
 
 authors = ['WWFX UK']
 
-# # Technically needs bash. Tested rez on Windows, Linux and OSX CI with bash
-# requires = []
+# Technically needs bash. Tested rez on Linux and OSX CI with bash
+requires = ['platform-linux|osx']
 
 tools = ['colourise', 'colour-test']  # Names of executables from this package
 # ---- OR ----

--- a/package.py
+++ b/package.py
@@ -11,8 +11,8 @@ description = (
 
 authors = ['WWFX UK']
 
-# # Technically needs bash. Tested on CI Windows, Linux and OSX with bash
-# requires = []
+# Technically needs bash. Tested rez on Linux and OSX CI with bash
+requires = ['platform-linux|osx']
 
 tools = ['colourise', 'colour-test']  # Names of executables from this package
 # ---- OR ----
@@ -45,12 +45,14 @@ set -euf -o pipefail
 [ -t 1 ] && CURL_FLAGS="-#" || CURL_FLAGS="-sS"
 CURL_FLAGS+=" -L"
 
+TAR_FLAGS="--strip-components=1 -xz"
+[ "$REZ_PLATFORM_VERSION" == "osx" ] || TAR_FLAGS+=" --wildcards"
+
 if [[ $REZ_BUILD_INSTALL -eq 1 ]]
 then
     curl $CURL_FLAGS \
         https://github.com/wwfxuk/colourise/archive/{version}.tar.gz \
-    | tar -C "$REZ_BUILD_INSTALL_PATH" --strip-components=1 -xz \
-        --wildcards {tools}
+    | tar -C "$REZ_BUILD_INSTALL_PATH" $TAR_FLAGS {tools}
 fi
 '''.format(version=version, tools=' '.join('"*/{0}"'.format(t) for t in tools))
 

--- a/package.py
+++ b/package.py
@@ -36,6 +36,7 @@ tools = ['colourise', 'colour-test']  # Names of executables from this package
 # # Technically needs tar, gzip and curl but they tend to come with OS
 # build_requires = []  # Build-time packages required by this package
 
+# To Do: Fails on Windows, rez will run build_command with cmd
 build_command = r'''
 set -euf -o pipefail
 


### PR DESCRIPTION
## [0.3.0] - 2019-10-25

Now available as rez package.

### Added

- `package.py` for [rez package](https://github.com/nerdvegas/rez).
- rez package install CI for Linux and OSX.
- Windows (bash) tests for CI